### PR TITLE
Boundaries and musl fixes for ROCm 6.x release

### DIFF
--- a/dev-libs/rocm-comgr/files/rocm-comgr-6.1.0-fix-comgr-default-flags.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-6.1.0-fix-comgr-default-flags.patch
@@ -1,6 +1,10 @@
 Remove HIP/ROCM includes ("-isystem /usr/include"), as they break inclusion of <math.h>.
 Add inclusion of Clang resource dir (e.g. /usr/lib/clang/17), as it is used in hip runtime like that.
-Issue: https://github.com/ROCm/clr/issues/82
+Remove hardcoded target to fix HIP on musl.
+
+Issues:
+* https://github.com/ROCm/clr/issues/82
+* https://github.com/ROCm/llvm-project/issues/92
 --- a/src/comgr-compiler.cpp
 +++ b/src/comgr-compiler.cpp
 @@ -1028,9 +1028,8 @@ AMDGPUCompiler::addTargetIdentifierFlags(llvm::StringRef IdentStr,
@@ -15,8 +19,12 @@ Issue: https://github.com/ROCm/clr/issues/82
  
    Args.push_back("-x");
  
-@@ -1055,9 +1054,7 @@ amd_comgr_status_t AMDGPUCompiler::addCompilationFlags() {
-     Args.push_back("x86_64-unknown-linux-gnu");
+@@ -1051,13 +1050,9 @@ amd_comgr_status_t AMDGPUCompiler::addCompilationFlags() {
+   case AMD_COMGR_LANGUAGE_HIP:
+     Args.push_back("hip");
+     Args.push_back("-std=c++11");
+-    Args.push_back("-target");
+-    Args.push_back("x86_64-unknown-linux-gnu");
      Args.push_back("--cuda-device-only");
      Args.push_back("-isystem");
 -    Args.push_back(ROCMIncludePath.c_str());

--- a/dev-libs/rocm-comgr/rocm-comgr-6.1.1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-6.1.1.ebuild
@@ -20,6 +20,11 @@ else
 	KEYWORDS="~amd64"
 fi
 
+DESCRIPTION="Radeon Open Compute Code Object Manager"
+HOMEPAGE="https://github.com/ROCm/ROCm-CompilerSupport"
+LICENSE="MIT"
+SLOT="0/$(ver_cut 1-2)"
+
 IUSE="test"
 RESTRICT="!test? ( test )"
 
@@ -36,11 +41,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-6.1.0-clang18-log_remarks_test.patch"
 	"${FILESDIR}/${PN}-6.1.0-dont-add-nogpulib.patch"
 )
-
-DESCRIPTION="Radeon Open Compute Code Object Manager"
-HOMEPAGE="https://github.com/ROCm/ROCm-CompilerSupport"
-LICENSE="MIT"
-SLOT="0/$(ver_cut 1-2)"
 
 RDEPEND=">=dev-libs/rocm-device-libs-${PV}
 	sys-devel/clang-runtime:=

--- a/dev-libs/rocr-runtime/rocr-runtime-5.1.3-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -32,6 +32,7 @@ RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
+	<=dev-libs/rocm-device-libs-6.0
 	sys-devel/clang
 	sys-devel/lld"
 BDEPEND="app-editors/vim-core"

--- a/dev-libs/rocr-runtime/rocr-runtime-5.3.3-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.3.3-r1.ebuild
@@ -32,6 +32,7 @@ RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
+	<=dev-libs/rocm-device-libs-6.0
 	sys-devel/clang
 	sys-devel/lld"
 BDEPEND="app-editors/vim-core"

--- a/dev-libs/rocr-runtime/rocr-runtime-5.4.3-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.4.3-r1.ebuild
@@ -32,6 +32,7 @@ RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
+	<=dev-libs/rocm-device-libs-6.0
 	sys-devel/clang
 	sys-devel/lld"
 BDEPEND="app-editors/vim-core"

--- a/dev-libs/rocr-runtime/rocr-runtime-5.5.1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.5.1.ebuild
@@ -32,6 +32,7 @@ RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
+	<=dev-libs/rocm-device-libs-6.0
 	sys-devel/clang
 	sys-devel/lld"
 BDEPEND="app-editors/vim-core"

--- a/dev-libs/rocr-runtime/rocr-runtime-5.7.1-r3.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.7.1-r3.ebuild
@@ -34,6 +34,7 @@ COMMON_DEPEND="dev-libs/elfutils
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
+	<=dev-libs/rocm-device-libs-6.0
 	sys-devel/clang:${LLVM_MAX_SLOT}=
 	sys-devel/lld:${LLVM_MAX_SLOT}="
 RDEPEND="${DEPEND}"

--- a/dev-libs/rocr-runtime/rocr-runtime-6.0.0-r2.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-6.0.0-r2.ebuild
@@ -33,7 +33,7 @@ COMMON_DEPEND="dev-libs/elfutils
 	x11-libs/libdrm"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
-	>=dev-libs/rocm-device-libs-${PV}
+	dev-libs/rocm-device-libs:${SLOT}
 	$(llvm_gen_dep '
 		sys-devel/clang:${LLVM_SLOT}=
 		sys-devel/lld:${LLVM_SLOT}=

--- a/dev-libs/rocr-runtime/rocr-runtime-6.1.1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-6.1.1.ebuild
@@ -34,7 +34,7 @@ COMMON_DEPEND="dev-libs/elfutils
 	x11-libs/libdrm"
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
-	>=dev-libs/rocm-device-libs-${PV}
+	>=dev-libs/rocm-device-libs-${PV}[${LLVM_USEDEP}]
 	$(llvm_gen_dep '
 		sys-devel/clang:${LLVM_SLOT}=
 		sys-devel/lld:${LLVM_SLOT}=

--- a/dev-util/hip/files/hip-6.1.1-fix-musl.patch
+++ b/dev-util/hip/files/hip-6.1.1-fix-musl.patch
@@ -1,0 +1,24 @@
+Fix "basename" and "__cpu_mask" definitions for musl
+
+Upstream PR: https://github.com/ROCm/clr/pull/83
+--- a/rocclr/os/os.hpp
++++ b/rocclr/os/os.hpp
+@@ -29,6 +29,7 @@
+ 
+ #if defined(__linux__)
+ #include <sched.h>
++#include <libgen.h>
+ #endif
+ 
+ #ifdef _WIN32
+@@ -377,6 +378,10 @@ ALWAYSINLINE address Os::currentStackPtr() {
+ 
+ #if defined(__linux__)
+ 
++#ifndef __GLIBC__
++typedef unsigned long int __cpu_mask;
++#endif
++
+ inline void Os::ThreadAffinityMask::init() { CPU_ZERO(&mask_); }
+ 
+ inline void Os::ThreadAffinityMask::set(uint cpu) { CPU_SET(cpu, &mask_); }

--- a/dev-util/hip/files/hip-test-6.1.1-fix-musl.patch
+++ b/dev-util/hip/files/hip-test-6.1.1-fix-musl.patch
@@ -1,0 +1,159 @@
+Fix musl errors:
+* reinterpret_cast from 'std::nullptr_t' to 'void **' is not allowed
+* error.h is GNU extension
+
+Upstream PR: https://github.com/ROCm/hip-tests/pull/463
+--- a/unit/rtc/headers/printf_common.h
++++ b/unit/rtc/headers/printf_common.h
+@@ -30,7 +30,6 @@ THE SOFTWARE.
+ #if defined(_WIN32)
+ #include <io.h>
+ #else
+-#include <error.h>
+ #include <unistd.h>
+ #endif
+ 
+@@ -110,7 +109,7 @@ struct CaptureStream {
+     saved_fd = dup(orig_fd);
+ 
+     if ((temp_fd = mkstemp(tempname)) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }
+@@ -118,11 +117,11 @@ struct CaptureStream {
+   void Begin() {
+     fflush(nullptr);
+     if (dup2(temp_fd, orig_fd) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+     if (close(temp_fd) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }
+@@ -130,11 +129,11 @@ struct CaptureStream {
+   void End() {
+     fflush(nullptr);
+     if (dup2(saved_fd, orig_fd) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+     if (close(saved_fd) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }
+@@ -148,7 +147,7 @@ struct CaptureStream {
+ 
+   ~CaptureStream() {
+     if (remove(tempname) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }
+--- a/unit/memory/hipMemRangeGetAttributes_old.cc
++++ b/unit/memory/hipMemRangeGetAttributes_old.cc
+@@ -268,7 +268,7 @@ TEST_CASE("Unit_hipMemRangeGetAttributes_NegativeTst") {
+     // Passing NULL as first parameter
+     SECTION("Passing NULL as first parameter") {
+       if (!CheckError(hipMemRangeGetAttributes(
+-                                      reinterpret_cast<void**>(NULL),
++                                      static_cast<void**>(NULL),
+                                       reinterpret_cast<size_t*>(dataSizes),
+                                       AttrArr, 4, Hmm, MEM_SIZE),
+                                       __LINE__)) {
+--- a/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor_old.cc
++++ b/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor_old.cc
+@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative") {
+   ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(NULL, f1, blockSize, 0);
+   REQUIRE(ret != hipSuccess);
+ 
+-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, NULL, blockSize, 0);
++  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, static_cast<void*>(NULL), blockSize, 0);
+   REQUIRE(ret != hipSuccess);
+ 
+   ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, 0, 0);
+--- a/unit/occupancy/hipOccupancyMaxPotentialBlockSize_old.cc
++++ b/unit/occupancy/hipOccupancyMaxPotentialBlockSize_old.cc
+@@ -37,7 +37,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative") {
+ 
+ #ifndef __HIP_PLATFORM_NVIDIA__
+   // nvcc doesnt support kernelfunc(NULL) for api
+-  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0);
++  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, static_cast<void*>(NULL), 0, 0);
+   REQUIRE(ret != hipSuccess);
+ #endif
+ }
+--- a/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
++++ b/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+@@ -48,7 +48,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters
+       blockSize);
+ 
+   SECTION("Kernel function is NULL") {
+-    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0),
++    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, static_cast<void*>(NULL), blockSize, 0),
+                     hipErrorInvalidDeviceFunction);
+   }
+ }
+--- a/unit/kernel/printf_common.h
++++ b/unit/kernel/printf_common.h
+@@ -24,7 +24,6 @@ THE SOFTWARE.
+ #define _STRESSTEST_PRINTF_COMMON_H_
+ 
+ #include <errno.h>
+-#include <error.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+@@ -47,17 +46,17 @@ struct CaptureStream {
+     saved_fd = dup(orig_fd);
+ 
+     if ((temp_fd = mkstemp(tempname)) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+ 
+     fflush(nullptr);
+     if (dup2(temp_fd, orig_fd) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+     if (close(temp_fd) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }
+@@ -67,11 +66,11 @@ struct CaptureStream {
+       return;
+     fflush(nullptr);
+     if (dup2(saved_fd, orig_fd) == -1) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+     if (close(saved_fd) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+     saved_fd = -1;
+@@ -90,7 +89,7 @@ struct CaptureStream {
+   ~CaptureStream() {
+     restoreStream();
+     if (remove(tempname) != 0) {
+-      error(0, errno, "Error");
++      fprintf(stderr, "Error: %s\n", strerror(errno));
+       assert(false);
+     }
+   }

--- a/dev-util/hip/hip-5.7.1-r2.ebuild
+++ b/dev-util/hip/hip-5.7.1-r2.ebuild
@@ -34,9 +34,9 @@ DEPEND="
 	x11-base/xorg-proto
 	virtual/opengl
 "
-BDEPEND="test? ( <dev-util/hipcc-6 )"
+BDEPEND="test? ( =dev-util/hipcc-5* )"
 RDEPEND="${DEPEND}
-	dev-util/hipcc
+	=dev-util/hipcc-5*
 	dev-perl/URI-Encode
 	sys-devel/clang-runtime:=
 	>=dev-libs/roct-thunk-interface-5"

--- a/dev-util/hip/hip-6.0.2.ebuild
+++ b/dev-util/hip/hip-6.0.2.ebuild
@@ -35,9 +35,9 @@ DEPEND="
 	x11-base/xorg-proto
 	virtual/opengl
 "
-BDEPEND="test? ( dev-util/hipcc )"
+BDEPEND="test? ( dev-util/hipcc:${SLOT}[${LLVM_USEDEP}] )"
 RDEPEND="${DEPEND}
-	dev-util/hipcc
+	dev-util/hipcc:${SLOT}[${LLVM_USEDEP}]
 	dev-perl/URI-Encode
 	sys-devel/clang-runtime:=
 	>=dev-libs/roct-thunk-interface-5"

--- a/dev-util/hip/hip-6.1.1.ebuild
+++ b/dev-util/hip/hip-6.1.1.ebuild
@@ -38,9 +38,9 @@ DEPEND="
 	x11-base/xorg-proto
 	virtual/opengl
 "
-BDEPEND="test? ( dev-util/hipcc )"
+BDEPEND="test? ( dev-util/hipcc:${SLOT}[${LLVM_USEDEP}] )"
 RDEPEND="${DEPEND}
-	dev-util/hipcc
+	dev-util/hipcc:${SLOT}[${LLVM_USEDEP}]
 	dev-perl/URI-Encode
 	sys-devel/clang-runtime:=
 	>=dev-libs/roct-thunk-interface-5"

--- a/dev-util/hip/hip-6.1.1.ebuild
+++ b/dev-util/hip/hip-6.1.1.ebuild
@@ -49,6 +49,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.7.1-no_asan_doc.patch"
 	"${FILESDIR}/${PN}-6.1.0-install.patch"
 	"${FILESDIR}/${PN}-6.1.0-extend-isa-compatibility-check.patch"
+	"${FILESDIR}/${PN}-6.1.1-fix-musl.patch"
 )
 
 hip_test_wrapper() {
@@ -79,6 +80,7 @@ src_prepare() {
 		"${FILESDIR}"/hip-test-6.0.2-hipcc-system-install.patch
 		"${FILESDIR}"/hip-test-5.7.1-remove-incompatible-flag.patch
 		"${FILESDIR}"/hip-test-6.1.0-disable-hipKerArgOptimization.patch
+		"${FILESDIR}"/hip-test-6.1.1-fix-musl.patch
 	)
 	hip_test_wrapper cmake_src_prepare
 }

--- a/dev-util/roctracer/roctracer-6.1.1.ebuild
+++ b/dev-util/roctracer/roctracer-6.1.1.ebuild
@@ -20,8 +20,10 @@ KEYWORDS="~amd64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-RDEPEND="dev-libs/rocr-runtime
-	dev-util/hip"
+RDEPEND="
+	dev-util/hip:${SLOT}
+	dev-libs/rocr-runtime
+"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	$(python_gen_any_dep '

--- a/sci-libs/caffe2/caffe2-2.1.2-r7.ebuild
+++ b/sci-libs/caffe2/caffe2-2.1.2-r7.ebuild
@@ -65,18 +65,18 @@ RDEPEND="
 	opencv? ( media-libs/opencv:= )
 	qnnpack? ( sci-libs/QNNPACK )
 	rocm? (
-		>=dev-util/hip-5.7
-		>=dev-libs/rccl-5.7[${ROCM_USEDEP}]
-		>=sci-libs/rocThrust-5.7[${ROCM_USEDEP}]
-		>=sci-libs/rocPRIM-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipBLAS-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipFFT-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipSPARSE-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipRAND-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipCUB-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipSOLVER-5.7[${ROCM_USEDEP}]
-		>=sci-libs/miopen-5.7[${ROCM_USEDEP}]
-		>=dev-util/roctracer-5.7[${ROCM_USEDEP}]
+		=dev-util/hip-5.7*
+		=dev-libs/rccl-5.7*[${ROCM_USEDEP}]
+		=sci-libs/rocThrust-5.7*[${ROCM_USEDEP}]
+		=sci-libs/rocPRIM-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipBLAS-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipFFT-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipSPARSE-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipRAND-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipCUB-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipSOLVER-5.7*[${ROCM_USEDEP}]
+		=sci-libs/miopen-5.7*[${ROCM_USEDEP}]
+		=dev-util/roctracer-5.7*[${ROCM_USEDEP}]
 	)
 	tensorpipe? ( sci-libs/tensorpipe[cuda?] )
 	xnnpack? ( >=sci-libs/XNNPACK-2022.12.22 )

--- a/sci-libs/caffe2/caffe2-2.2.2-r1.ebuild
+++ b/sci-libs/caffe2/caffe2-2.2.2-r1.ebuild
@@ -62,18 +62,18 @@ RDEPEND="
 	opencv? ( media-libs/opencv:= )
 	qnnpack? ( sci-libs/QNNPACK )
 	rocm? (
-		>=dev-util/hip-5.7
-		>=dev-libs/rccl-5.7[${ROCM_USEDEP}]
-		>=sci-libs/rocThrust-5.7[${ROCM_USEDEP}]
-		>=sci-libs/rocPRIM-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipBLAS-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipFFT-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipSPARSE-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipRAND-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipCUB-5.7[${ROCM_USEDEP}]
-		>=sci-libs/hipSOLVER-5.7[${ROCM_USEDEP}]
-		>=sci-libs/miopen-5.7[${ROCM_USEDEP}]
-		>=dev-util/roctracer-5.7[${ROCM_USEDEP}]
+		=dev-util/hip-5.7*
+		=dev-libs/rccl-5.7*[${ROCM_USEDEP}]
+		=sci-libs/rocThrust-5.7*[${ROCM_USEDEP}]
+		=sci-libs/rocPRIM-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipBLAS-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipFFT-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipSPARSE-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipRAND-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipCUB-5.7*[${ROCM_USEDEP}]
+		=sci-libs/hipSOLVER-5.7*[${ROCM_USEDEP}]
+		=sci-libs/miopen-5.7*[${ROCM_USEDEP}]
+		=dev-util/roctracer-5.7*[${ROCM_USEDEP}]
 	)
 	distributed? ( sci-libs/tensorpipe[cuda?] )
 	xnnpack? ( >=sci-libs/XNNPACK-2022.12.22 )


### PR DESCRIPTION
I tried to setup a clean docker container and `emerge =roctracer-6.1.1`  failed with multiple problems.

Also lock rocm 5.7.1 libraries for <=caffe2-2.1.2

There are also few musl-related issues (all reported to upstream).